### PR TITLE
Add missing TransactionStatus enum

### DIFF
--- a/src/modules/api/graphql/schema.ts
+++ b/src/modules/api/graphql/schema.ts
@@ -15,6 +15,7 @@ export const schema = `
         CONFIRMED
         FAILED
         INCLUDED
+        PROCESSED
     }
     enum TransactionType {
         NULL


### PR DESCRIPTION
Adds the `PROCESSED` status in the GraphQL schema.

Fixes the GraphQL query error:
```json
{
  "errors": [
    {
      "message": "Enum \"TransactionStatus\" cannot represent value: \"PROCESSED\"",
      "locations": [
        {
          "line": 6,
          "column": 5
        }
      ],
      "path": [
        "findTransaction",
        "status"
      ]
    }
  ],
  "data": {
    "findTransaction": {
      "id": "bafyreihk3phucbu7xud3xwdf4i3wjnhmz5frevvlywoxdtkmuxsdxuxd7y",
      "status": null,
      "op": "call_contract",
      "included_in": "bafyreib4kwwhmxs2g3ni6i4cpiizto3gzhrxbq276nan2hnhb7esztpv5a",
      "executed_in": null
    }
  }
}
```