### PR TITLE
add sem docker release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |   
+            ${{vars.DOCKERHUB_IMAGE}}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha            
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,32 @@
 
 < fill in >
 
-
 ## Installation
+
+### Docker compose
+
+Install [Docker](https://docs.docker.com/get-docker/) and [Docker compose](https://docs.docker.com/compose/install/).
+
+Download the Docker compose file [here](https://raw.githubusercontent.com/vsc-eco/vsc-node/main/deploy/docker-compose/docker-compose.yml).
+
+Assure that the Docker user has write permissions in the directory you startup the Docker compose file.
+
+Create an `.env` file according to the schema specified in the [.env.example](https://raw.githubusercontent.com/vsc-eco/vsc-node/main/.env.example) file and put it next to the docker compose file.
+
+``` txt
+# Fill these in with your hive account details
+HIVE_ACCOUNT=
+HIVE_ACCOUNT_POSTING=
+HIVE_ACCOUNT_ACTIVE=
+
+
+# Leave untouched unless instructed otherwise.
+MULTISIG_ACCOUNT=vsc.beta
+MULTISIG_ANTI_HACK=did:key:z6Mkj5mKz5EBnqqsyV2qBohYFuvTXpCuxzNMGSpa1FJRstze
+MULTISIG_ANTI_HACK_KEY=
+```
+
+Launch via `docker-compose up -d`.
 
 ### Ansible
 
@@ -42,5 +66,3 @@ On a high level the script
 1. register the update.sh script as a crown job to automatically keep the node up to date
 
 The bare_metal installation is currently not completed.
-
-

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,0 +1,61 @@
+version: "3.3"
+
+services:
+  vsc-node: # name of the service
+    image: platinium/vsc-node:latest
+    container_name: vsc-node # what to label the container for docker ps
+    restart: always # restart if failed, until we stop it ourselves
+    #external_links:
+      #- mongo
+    depends_on:
+      - ipfs
+    networks:
+      - vsc-node
+    ports:
+      - 1337:1337
+    environment:
+      IPFS_HOST: http://ipfs:5001
+      MONGO_HOST: mongo:27017
+    volumes:
+      - node-modules-store:/home/github/app/node_modules
+      - ./data/vsc-node:/root/.vsc-node
+      - ./seed-backup.json:/root/.vsc-seed-backup.json
+      - ./.git/refs/heads/main:/root/git_commit
+
+  mongo:
+    container_name: mongo_vsc
+    image: mongo:4.4.18
+    restart: always
+    ports:
+      - 127.0.0.1:27021:27017
+    networks:
+      - vsc-node
+    volumes:
+      - ./data/vsc-db:/data/db
+
+  ipfs:
+    container_name: ipfs-vsc
+    image: ipfs/kubo:v0.18.1
+    restart: always
+    command:
+      - daemon
+      - --enable-pubsub-experiment
+      - --init-profile
+      - server
+    networks:
+      - vsc-node
+    ports:
+      - "4001:4001"
+      - "127.0.0.1:5001:5001"
+    environment: 
+      IPFS_PATH: /etc/ipfs
+    volumes:
+      - ./data/ipfs:/etc/ipfs
+
+volumes:
+  node-modules-store: {}
+  mongodb: {}
+      
+networks:
+  vsc-node:
+    driver: bridge

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   vsc-node: # name of the service
-    image: platinium/vsc-node:latest
+    image: vaultec/vsc-node:latest
     container_name: vsc-node # what to label the container for docker ps
     restart: always # restart if failed, until we stop it ourselves
     #external_links:


### PR DESCRIPTION
adds github actions to autom. release docker images on push/ tag release

### behaviors

- latest tag is updated when a release/ tag is beeing created 
- tags are created for [branches, commits and semantic versions](https://hub.docker.com/r/platinium/vsc-node/tags)

### prerequisites before merge

- create dockerhub account
- configure repository secrets on github
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
https://docs.docker.com/build/ci/github-actions/#step-one-create-the-repository
- add repository environment variable (same menu like setting up secrets)
DOCKERHUB_IMAGE
value needs to match repositoryowner/anypath
ive used platinium/vsc-node for testing

### General notes

- Images are beeing built for arm/ amd64
- When reliable enough one of the compose files should be removed.

