### PR TITLE
Update docker-compose commands in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,11 +34,11 @@ echo "$indexVersion $indexVersionDeployed"
 
 if [ "$gitCommit" != "$deployedGitCommit" ];
 then
-  docker-compose down
+  docker compose down
 
   sleep 15; # Ensure safe shutdown
 
-  docker-compose build
+  docker compose build
 
 
   if [ "$indexVersion" -ne "$indexVersionDeployed" ];
@@ -54,7 +54,7 @@ then
   fi
 
 
-  docker-compose up -d
+  docker compose up -d
 
   echo $gitCommit > data/git-flag
 fi


### PR DESCRIPTION
Newer installations of Docker will run with `docker compose` but not with the `docker-compose` command. `docker compose` is now part of the docker CLI.