### PR TITLE
contract engine: pin contract code in block parser

### DIFF
--- a/src/services/new/contractEngineV2.ts
+++ b/src/services/new/contractEngineV2.ts
@@ -117,6 +117,9 @@ export class ContractEngineV2 {
                     })).cid
         
                     const bech32Addr = bech32.encode('vs4', bech32.toWords(contractIdHash.bytes));
+
+                    console.log('pinning contract CID', json.code);
+                    await this.self.ipfs.pin.add(json.code)
         
                     console.log('smart contract addr', bech32Addr)
                     await this.contractDb.findOneAndUpdate({

--- a/src/services/new/witness/versionManager.ts
+++ b/src/services/new/witness/versionManager.ts
@@ -6,7 +6,7 @@ import { Collection } from "mongodb";
 
 
 export const VersionConfig = {
-    index_reset_id: 8,
+    index_reset_id: 9,
     //Match with package.json and tag
     version_id: 'v0.1.2'
 }


### PR DESCRIPTION
contracts should be pinned immediately when deployed