### PR TITLE
Fix contract hang

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,7 @@ services:
       - ./seed-backup.json:/root/.vsc-seed-backup.json
       - ./.git/refs/heads/main:/root/git_commit
       - ./src:/home/github/app/src
+      - ./dist:/home/github/app/dist
 
   mongo:
     container_name: mongo_vsc_dev

--- a/src/services/new/contractEngineV2.ts
+++ b/src/services/new/contractEngineV2.ts
@@ -45,6 +45,7 @@ class VmContext {
 
     async init() {
         let args = {
+            debug: true,
             state: {
 
             },
@@ -61,7 +62,9 @@ class VmContext {
         }
         this.vm = new VmContainer(args)
 
+        console.log('vm init')
         await this.vm.init()
+        console.log('vm readying')
         await this.vm.onReady()
     }
 

--- a/src/services/new/vm/utils.ts
+++ b/src/services/new/vm/utils.ts
@@ -434,8 +434,11 @@ export class VmContainer {
     this.child.kill()
   }
 
-  onReady() {
-    return new Promise((resolve) => {
+  async onReady() {
+    if (this.ready) {
+      return
+    }
+    return new Promise<void>((resolve) => {
       this.events.on('ready', resolve)
     })
   }

--- a/src/services/new/vm/vm-runner.ts
+++ b/src/services/new/vm/vm-runner.ts
@@ -464,8 +464,12 @@ class VmRunner {
 
     let modules = {}
     for (let [contract_id, code] of Object.entries<string>(this.modules)) {
-      const binaryData = await ipfs.block.get(IPFS.CID.parse(code))
-      modules[contract_id] = await WebAssembly.compile(binaryData)
+      const binaryData = await ipfs.dag.get(IPFS.CID.parse(code))
+      try {
+        modules[contract_id] = await WebAssembly.compile(binaryData.value)
+      } catch (e) {
+        console.error(`invalid contract code ${contract_id}`, e)
+      }
     }
 
     let state = {}

--- a/src/services/new/vm/vm-runner.ts
+++ b/src/services/new/vm/vm-runner.ts
@@ -767,6 +767,7 @@ class VmRunner {
           type: 'execute-stop',
           ret: str,
           logs,
+          error: null,
           // reqId: message.reqId,
           IOGas,
         }
@@ -789,6 +790,7 @@ class VmRunner {
           return {
             type: 'execute-stop',
             ret: null,
+            error: ex.toString(),
             errorType: ContractErrorType.RUNTIME_UNKNOWN,
             logs,
             // reqId: message.reqId,
@@ -802,6 +804,7 @@ class VmRunner {
         type: 'execute-stop',
         ret: null,
         logs,
+        error: ex.toString(),
         errorType: ContractErrorType.RUNTIME_SETUP,
         // reqId: message.reqId,
         IOGas,

--- a/src/services/new/witness/index.ts
+++ b/src/services/new/witness/index.ts
@@ -387,6 +387,7 @@ export class WitnessServiceV2 {
         console.log('contractIds', contractIds)
         const vmContext = this.self.contractEngine.vmContext(contractIds);
         await vmContext.init()
+        console.log('initalized vm')
         
         let results: Record<string, Array<any>> = {
 
@@ -395,7 +396,9 @@ export class WitnessServiceV2 {
         for(let tx of transactions) {
           if(tx.data.contract_id) {
             const contract_id = tx.data.contract_id
+            console.log('processing tx', JSON.stringify(tx, null, 2))
             const contractCallResult = await vmContext.processTx(tx)
+            console.log('completed tx', JSON.stringify(contractCallResult, null, 2))
             if(!results[contract_id]) {
               results[contract_id] = []
             }


### PR DESCRIPTION
Fixes the node hang issue due to contract exec failures and incorrect method of pull IPFS DAG style data.

Soon, I will follow up this PR with extra verification during the data availability proof step during deployment to ensure not only that the contract code is proper WebAssembly, but also, that it exports the AssemblyScript runtime as we expect and the list of exported entry points that are available.